### PR TITLE
Set default values for some settings to prevent compiler warnings.

### DIFF
--- a/Controls.cs
+++ b/Controls.cs
@@ -29,14 +29,23 @@
                 ACCEPT_CALLOUT = new Control()
                 {
                     Key = Keys.Y,
+                    ModifierKey = Keys.None,
+                    Button = ControllerButtons.None,
+                    ModifierButton = ControllerButtons.None,
                 },
                 FORCE_CALLOUT = new Control()
                 {
                     Key = Keys.X,
+                    ModifierKey = Keys.None,
+                    Button = ControllerButtons.None,
+                    ModifierButton = ControllerButtons.None,
                 },
                 END_CALLOUT = new Control()
                 {
                     Key = Keys.End,
+                    ModifierKey = Keys.None,
+                    Button = ControllerButtons.None,
+                    ModifierButton = ControllerButtons.None,
                 },
             };
         }

--- a/Settings.cs
+++ b/Settings.cs
@@ -183,11 +183,20 @@
                 VEHICLES = new VehiclesSettings()
                 {
                     ENGINE_MODEL = "FIRETRUK",
+                    ENGINE_PRIMARY_COLOR = null,
+                    ENGINE_SECONDARY_COLOR = null,
+
                     RESCUE_MODEL = "FIRETRUK",
+                    RESCUE_PRIMARY_COLOR = null,
+                    RESCUE_SECONDARY_COLOR = null,
+
                     BATTALION_MODEL = "FBI2",
                     BATTALION_PRIMARY_COLOR = new ColorData() { R = 200, G = 0, B = 0 },
+                    BATTALION_SECONDARY_COLOR = null,
 
                     AMBULANCE_MODEL = "AMBULANCE",
+                    AMBULANCE_PRIMARY_COLOR = null,
+                    AMBULANCE_SECONDARY_COLOR = null,
                 },
 
                 PEDS = new PedsSettings()


### PR DESCRIPTION
Added default null values for settings that are not required, to prevent unused variable warnings.