### PR TITLE
Addons

### DIFF
--- a/API/Addon.cs
+++ b/API/Addon.cs
@@ -1,0 +1,14 @@
+﻿namespace EmergencyV.API
+{
+    public abstract class Addon
+    {
+        public abstract string Name { get; }
+
+        protected Addon()
+        {
+        }
+
+        public abstract void OnStart();
+        public abstract void OnCleanUp();
+    }
+}

--- a/API/Functions.cs
+++ b/API/Functions.cs
@@ -9,12 +9,31 @@
     public static class Functions
     {
         public delegate void PlayerDutyStateChangedEventHandler(PlayerStateType currentState, PlayerStateType previousState);
+        public delegate void RegisteringCalloutsEventHandler();
 
         public static event PlayerDutyStateChangedEventHandler PlayerStateChanged;
+
+        /// <summary>
+        /// Occurs when the <see cref="Callout"/>s with the <see cref="FireCalloutInfoAttribute"/> are being registered. Use this event to manually register firefighter callouts with <see cref="RegisterFirefighterCallout(Type, string, FirefighterRole, CalloutProbability)"/>.
+        /// </summary>
+        public static event RegisteringCalloutsEventHandler RegisteringFirefighterCallouts;
+        /// <summary>
+        /// Occurs when the <see cref="Callout"/>s with the <see cref="EMSCalloutInfoAttribute"/> are being registered. Use this event to manually register firefighter callouts with <see cref="RegisterEMSCallout(Type, string, CalloutProbability)(Type, string, FirefighterRole, CalloutProbability)"/>.
+        /// </summary>
+        public static event RegisteringCalloutsEventHandler RegisteringEMSCallouts;
 
         internal static void OnPlayerStateChanged(PlayerStateType currentState, PlayerStateType previousState)
         {
             PlayerStateChanged?.Invoke(currentState, previousState);
+        }
+
+        internal static void OnRegisteringCallouts<TCalloutData, TCalloutInfoAttribute>(CalloutsManager<TCalloutData, TCalloutInfoAttribute> calloutsManager) where TCalloutData : RegisteredCalloutData
+                                                                                                                                                              where TCalloutInfoAttribute : CalloutInfoAttribute
+        {
+            if (calloutsManager is FireCalloutsManager)
+                RegisteringFirefighterCallouts?.Invoke();
+            else if(calloutsManager is EMSCalloutsManager)
+                RegisteringEMSCallouts?.Invoke();
         }
 
         public static ScriptedFire[] CreateFires(Vector3[] positions, int maxChildren, bool isGasFire, bool onGround = true)

--- a/AddonsManager.cs
+++ b/AddonsManager.cs
@@ -1,0 +1,78 @@
+﻿namespace EmergencyV
+{
+    // System
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Collections.Generic;
+
+    // RPH
+    using Rage;
+
+    internal class AddonsManager
+    {
+        private static AddonsManager instance;
+        public static AddonsManager Instance
+        {
+            get
+            {
+                if (instance == null)
+                    instance = new AddonsManager();
+                return instance;
+            }
+        }
+
+        public List<API.Addon> CurrentAddons = new List<API.Addon>();
+
+        private AddonsManager()
+        {
+        }
+
+        public void LoadAddons()
+        {
+            Game.LogTrivial($"{this.GetType().Name}: Loading addons...");
+
+            string[] files = Directory.GetFiles(Plugin.AddonsFolder, "*.dll", SearchOption.TopDirectoryOnly);
+            UnloadAddons();
+
+            if (files.Length >= 1)
+            {
+                foreach (string file in files)
+                {
+                    // may need to check if it's a valid .NET dll
+                    Assembly assembly = Assembly.LoadFrom(file);
+
+                    Type[] addonsTypes = assembly.GetTypes().Where(t => !t.IsAbstract &&
+                                                                          t.IsSubclassOf(typeof(API.Addon))).ToArray();
+                    
+                    foreach (Type t in addonsTypes)
+                    {
+                        Game.LogTrivial($"{this.GetType().Name}: Creating addon {t.Name} instance...");
+                        API.Addon instance = (API.Addon)Activator.CreateInstance(t);
+                        CurrentAddons.Add(instance);
+
+                        Game.LogTrivial($"      Addon({instance.Name}) - OnStart()");
+                        instance.OnStart();
+                    }
+                }
+
+                Game.LogTrivial($"{this.GetType().Name}: Loaded " + CurrentAddons.Count + " addons");
+            }
+        }
+
+        public void UnloadAddons()
+        {
+            if (CurrentAddons.Count >= 1)
+            {
+                Game.LogTrivial($"{this.GetType().Name}: Unloading addons...");
+                foreach (API.Addon a in CurrentAddons)
+                {
+                    Game.LogTrivial($"      Addon({a.Name}) - OnCleanUp()");
+                    a.OnCleanUp();
+                }
+                CurrentAddons.Clear();
+            }
+        }
+    }
+}

--- a/EmergencyV Default Callouts/EmergencyV Default Callouts.csproj
+++ b/EmergencyV Default Callouts/EmergencyV Default Callouts.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>E:\Rockstar Games\Grand Theft Auto V\Plugins\Emergency V\Callouts\</OutputPath>
+    <OutputPath>E:\Rockstar Games\Grand Theft Auto V\Plugins\Emergency V\Addons\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>E:\Rockstar Games\Grand Theft Auto V\Plugins\Emergency V\Callouts\</OutputPath>
+    <OutputPath>E:\Rockstar Games\Grand Theft Auto V\Plugins\Emergency V\Addons\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Main.cs" />
     <Compile Include="StructureFire.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/EmergencyV Default Callouts/Main.cs
+++ b/EmergencyV Default Callouts/Main.cs
@@ -1,0 +1,33 @@
+﻿namespace EmergencyVDefaultCallouts
+{
+    using System;
+    using Rage;
+    using EmergencyV.API;
+
+    internal class Main : Addon
+    {
+        public override string Name
+        {
+            get
+            {
+                return "Test Addon";
+            }
+        }
+
+        public override void OnCleanUp()
+        {
+            Game.Console.Print("FROM ADDON: OnCleanUp()");
+        }
+
+        public override void OnStart()
+        {
+            Game.Console.Print("FROM ADDON: OnStart()");
+            Functions.PlayerStateChanged += Functions_PlayerStateChanged;
+        }
+
+        private void Functions_PlayerStateChanged(EmergencyV.PlayerStateType currentState, EmergencyV.PlayerStateType previousState)
+        {
+            Game.Console.Print($"FROM ADDON: PlayerStateChanged-Currrent{currentState}-Previous{previousState}");
+        }
+    }
+}

--- a/EmergencyV Default Callouts/Main.cs
+++ b/EmergencyV Default Callouts/Main.cs
@@ -23,11 +23,30 @@
         {
             Game.Console.Print("FROM ADDON: OnStart()");
             Functions.PlayerStateChanged += Functions_PlayerStateChanged;
+            Functions.RegisteringFirefighterCallouts += Functions_RegisteringFirefighterCallouts;
+            Functions.RegisteringEMSCallouts += Functions_RegisteringEMSCallouts;
+        }
+
+        private void Functions_RegisteringEMSCallouts()
+        {
+            Game.Console.Print($"FROM ADDON: RegisteringEMSCallouts");
+            Functions.RegisterEMSCallout(typeof(callout), "CALLOUT FROM ADDON", EmergencyV.CalloutProbability.VeryHigh);
+        }
+
+        private void Functions_RegisteringFirefighterCallouts()
+        {
+            Game.Console.Print($"FROM ADDON: RegisteringFirefighterCallouts");
+            Functions.RegisterFirefighterCallout(typeof(callout), "CALLOUT FROM ADDON", EmergencyV.FirefighterRole.Engine, EmergencyV.CalloutProbability.VeryHigh);
         }
 
         private void Functions_PlayerStateChanged(EmergencyV.PlayerStateType currentState, EmergencyV.PlayerStateType previousState)
         {
             Game.Console.Print($"FROM ADDON: PlayerStateChanged-Currrent{currentState}-Previous{previousState}");
         }
+    }
+
+
+    internal class callout : EmergencyV.Callout
+    {
     }
 }

--- a/EmergencyV.csproj
+++ b/EmergencyV.csproj
@@ -52,6 +52,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddonsManager.cs" />
+    <Compile Include="API\Addon.cs" />
     <Compile Include="API\Functions.cs" />
     <Compile Include="API\ScriptedFire.cs" />
     <Compile Include="Controls.cs" />

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -13,6 +13,7 @@
     internal static class Plugin
     {
         public const string ResourcesFolder = @"Plugins\Emergency V\";
+        public const string AddonsFolder = ResourcesFolder + @"Addons\";
 
         public static readonly Random Random = new Random();
 
@@ -35,12 +36,17 @@
             if (!Directory.Exists(ResourcesFolder))
                 Directory.CreateDirectory(ResourcesFolder);
 
+            if (!Directory.Exists(AddonsFolder))
+                Directory.CreateDirectory(AddonsFolder);
+
             LoadControls();
             LoadSettings();
 
             UIManager.Instance.Init();
 
             RespawnController.Instance.StartFiber();
+
+            AddonsManager.Instance.LoadAddons();
 
             HoseTest hose = new HoseTest();
             while (true)
@@ -110,6 +116,8 @@
 
         private static void OnUnload(bool isTerminating)
         {
+            AddonsManager.Instance.UnloadAddons();
+
             FireStationsManager.Instance.CleanUp(isTerminating);
             //PlayerManager.Instance.CleanUp(isTerminating);
             //PlayerEquipmentManager.Instance.CleanUp(isTerminating);

--- a/Shared/Callouts/CalloutsManager.cs
+++ b/Shared/Callouts/CalloutsManager.cs
@@ -13,8 +13,6 @@
     internal abstract class CalloutsManager<TCalloutData, TCalloutInfoAttribute> where TCalloutData : RegisteredCalloutData
                                                                                  where TCalloutInfoAttribute : CalloutInfoAttribute
     {
-        public const string CalloutsFolder = Plugin.ResourcesFolder + @"Callouts\";
-
         protected List<TCalloutData> RegisteredCalloutsData = new List<TCalloutData>();
         public bool HasLoadedCallouts { get { return RegisteredCalloutsData != null && RegisteredCalloutsData.Count >= 1; } }
 
@@ -36,8 +34,6 @@
 
         protected CalloutsManager()
         {
-            if (!Directory.Exists(CalloutsFolder))
-                Directory.CreateDirectory(CalloutsFolder);
         }
 
         public void Update()
@@ -163,7 +159,7 @@
         {
             Game.LogTrivial($"{this.GetType().Name}: Loading callouts...");
 
-            string[] files = Directory.GetFiles(CalloutsFolder, "*.dll", SearchOption.TopDirectoryOnly);
+            string[] files = Directory.GetFiles(Plugin.AddonsFolder, "*.dll", SearchOption.TopDirectoryOnly);
             RegisteredCalloutsData.Clear();
 
             if (files.Length >= 1)

--- a/Shared/Callouts/CalloutsManager.cs
+++ b/Shared/Callouts/CalloutsManager.cs
@@ -162,6 +162,8 @@
             string[] files = Directory.GetFiles(Plugin.AddonsFolder, "*.dll", SearchOption.TopDirectoryOnly);
             RegisteredCalloutsData.Clear();
 
+            API.Functions.OnRegisteringCallouts(this);
+
             if (files.Length >= 1)
             {
                 foreach (string file in files)


### PR DESCRIPTION
Fairly simple addons system similar to the callouts system, any type inherited from the Addon class and in the addons folder will be loaded automatically by the AddonsManager when EmergencyV is loaded. OnStart() is called right after the addon is loaded and OnCleanUp(), when EmergencyV is unloaded.

Callouts are also loaded from the addons folder now.

And added RegisteringCallouts events to the API.