### PR TITLE
Menu

### DIFF
--- a/API/Functions.cs
+++ b/API/Functions.cs
@@ -216,5 +216,104 @@
                 return null;
             return result;
         }
+
+        /// <summary>
+        /// Determines whether the menu with the specified identifier exists.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The menu's identifier.</param>
+        /// <returns>
+        ///   <c>true</c> if the menu exists; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsMenuAdded(string uniqueIdentifier)
+        {
+            return PluginMenu.Instance.IsMenuAdded(uniqueIdentifier);
+        }
+
+        /// <summary>
+        /// Determines whether the menu item with the specified identifier exists.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The item's identifier.</param>
+        /// <returns>
+        ///   <c>true</c> if the item exists; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsItemAdded(string uniqueIdentifier)
+        {
+            return PluginMenu.Instance.IsItemAdded(uniqueIdentifier);
+        }
+
+        /// <summary>
+        /// Creates a menu with the specified identifier.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The identifier. Needs to be unique.</param>
+        public static void AddMenu(string uniqueIdentifier)
+        {
+            PluginMenu.Instance.AddMenu(uniqueIdentifier);
+        }
+
+        /// <summary>
+        /// Removes the menu with the specified identifier and all its items.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The menu's identifier.</param>
+        public static void RemoveMenu(string uniqueIdentifier)
+        {
+            PluginMenu.Instance.RemoveItem(uniqueIdentifier);
+        }
+
+        /// <summary>
+        /// Creates a menu item and adds it to a menu.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The item's identifier. Needs to be unique.</param>
+        /// <param name="menuIdentifier">
+        /// The identifier of the menu to add this item to. 
+        /// <p>It can be from a menu created with <see cref="AddMenu(string)"/> or one of the defaults menus: "MAIN_MENU", "ACTIONS_MENU" or "REQUEST_BACKUP_MENU".</p>
+        /// </param>
+        /// <param name="text">The caption of this item.</param>
+        /// <param name="callback">
+        /// The callback. Executed when the item is selected.
+        /// <p>Set to null if no callback should be executed.</p>
+        /// </param>
+        /// <param name="shortcutControl">
+        /// The control that will execute the <paramref name="callback"/> when pressed.
+        /// <p>Set to null if the <paramref name="callback"/> shouldn't have a shortcut.</p>
+        /// </param>
+        /// <param name="submenuToBindIdentifier">
+        /// The identifier of the submenu to bind this item to.
+        /// <p>The binded menu will be opened when this item is selected. If null no menu will be binded to this item.</p>
+        /// </param>
+        public static void AddItem(string uniqueIdentifier, string menuIdentifier, string text, Action callback = null, Control? shortcutControl = null, string submenuToBindIdentifier = null)
+        {
+            PluginMenu.Instance.AddItem(uniqueIdentifier, menuIdentifier, text, callback, shortcutControl, submenuToBindIdentifier);
+        }
+
+        /// <summary>
+        /// Removes the item with the specified identifier.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The item's identifier.</param>
+        public static void RemoveItem(string uniqueIdentifier)
+        {
+            PluginMenu.Instance.RemoveItem(uniqueIdentifier);
+        }
+
+        /// <summary>
+        /// Updates the properties of the item with the specified identifier.
+        /// </summary>
+        /// <param name="uniqueIdentifier">The item's identifier.</param>
+        /// <param name="text">The caption of this item.</param>
+        /// <param name="callback">
+        /// The callback. Executed when the item is selected.
+        /// <p>Set to null if no callback should be executed.</p>
+        /// </param>
+        /// <param name="shortcutControl">
+        /// The control that will execute the <paramref name="callback"/> when pressed.
+        /// <p>Set to null if the <paramref name="callback"/> shouldn't have a shortcut.</p>
+        /// </param>
+        /// <param name="submenuToBindIdentifier">
+        /// The identifier of the submenu to bind this item to.
+        /// <p>The binded menu will be opened when this item is selected. If null no menu will be binded to this item.</p>
+        /// </param>
+        public static void UpdateItem(string uniqueIdentifier, string text, Action callback = null, Control? shortcutControl = null, string submenuToBindIdentifier = null)
+        {
+            PluginMenu.Instance.UpdateItem(uniqueIdentifier, text, callback, shortcutControl, submenuToBindIdentifier);
+        }
     }
 }

--- a/Controls.cs
+++ b/Controls.cs
@@ -57,6 +57,8 @@
                 { "ACCEPT_CALLOUT", new Control(System.Windows.Forms.Keys.Y, ControllerButtons.None) },
                 { "FORCE_CALLOUT", new Control(System.Windows.Forms.Keys.X, ControllerButtons.None) },
                 { "END_CALLOUT", new Control(System.Windows.Forms.Keys.End, ControllerButtons.None) },
+                { "OPEN_MENU", new Control(System.Windows.Forms.Keys.F5, ControllerButtons.None) },
+                { "TOGGLE_FLASHLIGHT", new Control(System.Windows.Forms.Keys.L, ControllerButtons.None) },
             };
         }
     }
@@ -116,6 +118,21 @@
 
                 return modifierKeyPressed && (Key == Keys.None ? false : Game.IsKeyDownRightNow(Key));
             }
+        }
+
+        public string GetDisplayText()
+        {
+            bool usingController = IsUsingController;
+
+            string modifierText = usingController ?
+                                    ModifierButton == ControllerButtons.None ? "" : $"{ModifierButton} + " :
+                                    ModifierKey == Keys.None ? "" : $"{ModifierKey} + ";
+
+            string keyText = usingController ?
+                                    Button == ControllerButtons.None ? "" : $"{Button}" :
+                                    Key == Keys.None ? "" : $"{Key}";
+
+            return modifierText + keyText;
         }
     }
 

--- a/EmergencyV.csproj
+++ b/EmergencyV.csproj
@@ -67,11 +67,14 @@
     <Compile Include="EMS\Callouts\EMSCalloutsManager.cs" />
     <Compile Include="EMS\Callouts\EMSRegisteredCalloutData.cs" />
     <Compile Include="Engine\RotatedVector3.cs" />
+    <Compile Include="Engine\UI\Menu\Menu.cs" />
+    <Compile Include="Engine\UI\Menu\MenuItem.cs" />
     <Compile Include="Engine\UI\Notification.cs" />
     <Compile Include="Engine\UI\PercentageBar.cs" />
     <Compile Include="Engine\UI\NotificationsManager.cs" />
     <Compile Include="Engine\Util.cs" />
     <Compile Include="Firefighter\Callouts\FireCalloutInfoAttribute.cs" />
+    <Compile Include="PluginMenu.cs" />
     <Compile Include="RespawnController.cs" />
     <Compile Include="Shared\Building.cs" />
     <Compile Include="Shared\BuildingData.cs" />

--- a/Engine/UI/Menu/Menu.cs
+++ b/Engine/UI/Menu/Menu.cs
@@ -44,7 +44,7 @@
         public MenuItem SelectedItem
         {
             get { return selectedItem; }
-            private set
+            set
             {
                 if (value == selectedItem)
                     return;
@@ -63,6 +63,22 @@
             Items = new List<MenuItem>();
             Fiber = GameFiber.StartNew(UpdateLoop, "Menu Fiber");
             Game.RawFrameRender += OnRawFrameRender;
+        }
+
+        public void CloseSubmenu()
+        {
+            if (IsInSubmenu)
+            {
+                OpenedSubmenu.IsVisible = false;
+                OpenedSubmenu = null;
+                IsInSubmenu = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            Fiber.Abort();
+            Game.RawFrameRender -= OnRawFrameRender;
         }
 
         private void MoveUp()
@@ -152,9 +168,9 @@
             for (int i = 0; i < Items.Count; i++)
             {
                 MenuItem item = Items[i];
-                if (item.ShortcutControl.HasValue && item.ShortcutControl.Value.IsJustPressed())
+                if (item.Callback != null && item.ShortcutControl.HasValue && item.ShortcutControl.Value.IsJustPressed())
                 {
-                    item.Callback?.Invoke();
+                    item.Callback.Invoke();
                 }
             }
         }

--- a/Engine/UI/Menu/Menu.cs
+++ b/Engine/UI/Menu/Menu.cs
@@ -1,0 +1,229 @@
+﻿namespace EmergencyV
+{
+    // System
+    using System.Collections.Generic;
+
+    // RPH
+    using Rage;
+    using Rage.Native;
+
+    internal class Menu
+    {
+        public GameFiber Fiber { get; }
+
+        private bool isVisible;
+        public bool IsVisible
+        {
+            get { return isVisible; }
+            set
+            {
+                if (value == isVisible)
+                    return;
+                isVisible = value;
+                if (IsInSubmenu)
+                    OpenedSubmenu.IsVisible = value;
+            }
+        }
+
+        private Menu parentMenu;
+        public Menu ParentMenu
+        {
+            get { return parentMenu; }
+            set
+            {
+                if (value == parentMenu)
+                    return;
+                parentMenu = value;
+                X = parentMenu.X - MenuItem.ItemWidth - 10.0f;
+            }
+        }
+
+        public List<MenuItem> Items { get; set; }
+
+        private MenuItem selectedItem;
+        public MenuItem SelectedItem
+        {
+            get { return selectedItem; }
+            private set
+            {
+                if (value == selectedItem)
+                    return;
+                selectedItem = value;
+                SelectedItemIndex = Items.IndexOf(selectedItem);
+            }
+        }
+        public int SelectedItemIndex { get; private set; }
+
+        public float X { get; set; } = (Game.Resolution.Width - MenuItem.ItemWidth - 10.0f);
+        public bool IsInSubmenu { get; private set; }
+        public Menu OpenedSubmenu { get; private set; }
+
+        public Menu()
+        {
+            Items = new List<MenuItem>();
+            Fiber = GameFiber.StartNew(UpdateLoop, "Menu Fiber");
+            Game.RawFrameRender += OnRawFrameRender;
+        }
+
+        private void MoveUp()
+        {
+            if (Items.Count == 0 || SelectedItem == null)
+                return;
+
+            int currentIndex = SelectedItemIndex;
+            if (currentIndex != -1)
+            {
+                int nextIndex = currentIndex - 1;
+                if (nextIndex >= 0)
+                    SelectedItem = Items[nextIndex];
+            }
+        }
+
+        private void MoveDown()
+        {
+            if (Items.Count == 0 || SelectedItem == null)
+                return;
+
+            int currentIndex = SelectedItemIndex;
+            if (currentIndex != -1)
+            {
+                int nextIndex = currentIndex + 1;
+                if (nextIndex < Items.Count)
+                    SelectedItem = Items[nextIndex];
+            }
+        }
+
+        private void UpdateLoop()
+        {
+            while (true)
+            {
+                GameFiber.Yield();
+                OnUpdate();
+            }
+        }
+
+
+        private void OnUpdate()
+        {
+            if (Game.Console.IsOpen)
+                return;
+
+            if (IsVisible)
+            {
+                if (SelectedItem == null && Items.Count > 0)
+                {
+                    SelectedItem = Items[0];
+                }
+
+                if (!IsInSubmenu)
+                {
+                    DisableControls();
+
+                    if (Game.IsControlJustPressed(0, GameControl.FrontendUp)) // up
+                    {
+                        MoveUp();
+                    }
+                    else if (Game.IsControlJustPressed(0, GameControl.FrontendDown)) // down
+                    {
+                        MoveDown();
+                    }
+                    else if (SelectedItem != null && Game.IsControlJustPressed(0, GameControl.FrontendAccept))
+                    {
+                        if (SelectedItem.BindedSubmenu != null)
+                        {
+                            GameFiber.Sleep(5); // sleep, otherwise will activate the selected item in the submenu
+                            SelectedItem.BindedSubmenu.IsVisible = true;
+                            OpenedSubmenu = SelectedItem.BindedSubmenu;
+                            IsInSubmenu = true;
+                        }
+
+                        SelectedItem?.Callback?.Invoke();
+                    }
+                    else if (parentMenu != null && Game.IsControlJustPressed(0, GameControl.FrontendRight))
+                    {
+                        parentMenu.IsInSubmenu = false;
+                        OpenedSubmenu = null;
+                        IsVisible = false;
+                    }
+                }
+                
+            }
+
+            for (int i = 0; i < Items.Count; i++)
+            {
+                MenuItem item = Items[i];
+                if (item.ShortcutControl.HasValue && item.ShortcutControl.Value.IsJustPressed())
+                {
+                    item.Callback?.Invoke();
+                }
+            }
+        }
+
+        private void OnRawFrameRender(object sender, GraphicsEventArgs e)
+        {
+            if (IsVisible)
+            {
+                Graphics g = e.Graphics;
+                for (int i = 0; i < Items.Count; i++)
+                {
+                    Items[i].OnDraw(g, X, i - SelectedItemIndex);
+                }
+            }
+        }
+
+        private static void DisableControls()
+        {
+            foreach (GameControl control in System.Enum.GetValues(typeof(GameControl)))
+            {
+                Game.DisableControlAction(0, control, true);
+                //NativeFunction.CallByName<uint>("DISABLE_CONTROL_ACTION", 1, (int)con);
+                //NativeFunction.CallByName<uint>("DISABLE_CONTROL_ACTION", 2, (int)con);
+            }
+            //Controls we want
+            // -Frontend
+            // -Mouse
+            // -Walk/Move
+            // -
+
+            foreach (GameControl control in controlsWhitelist)
+            {
+                NativeFunction.Natives.EnableControlAction(0, (int)control);
+            }
+        }
+
+        private static List<GameControl> controlsWhitelist = new List<GameControl>
+        {
+            GameControl.FrontendAccept,
+            GameControl.FrontendAxisX,
+            GameControl.FrontendAxisY,
+            GameControl.FrontendDown,
+            GameControl.FrontendUp,
+            GameControl.FrontendLeft,
+            GameControl.FrontendRight,
+            GameControl.FrontendCancel,
+            GameControl.FrontendSelect,
+            GameControl.CursorScrollDown,
+            GameControl.CursorScrollUp,
+            GameControl.CursorX,
+            GameControl.CursorY,
+            GameControl.MoveUpDown,
+            GameControl.MoveLeftRight,
+            GameControl.Sprint,
+            GameControl.Jump,
+            GameControl.Enter,
+            GameControl.VehicleExit,
+            GameControl.VehicleAccelerate,
+            GameControl.VehicleBrake,
+            GameControl.VehicleMoveLeftRight,
+            GameControl.VehicleFlyYawLeft,
+            GameControl.ScriptedFlyLeftRight,
+            GameControl.ScriptedFlyUpDown,
+            GameControl.VehicleFlyYawRight,
+            GameControl.VehicleHandbrake,
+            GameControl.LookUpDown,
+            GameControl.LookLeftRight,
+            GameControl.Aim,
+            GameControl.Attack,
+        };
+    }
+}

--- a/Engine/UI/Menu/MenuItem.cs
+++ b/Engine/UI/Menu/MenuItem.cs
@@ -1,0 +1,64 @@
+﻿namespace EmergencyV
+{
+    // System
+    using System;
+    using System.Drawing;
+
+    // RPH
+    using Rage;
+    using Graphics = Rage.Graphics;
+
+    internal class MenuItem
+    {
+        public const float ItemWidth = 325.0f;
+        public const float ItemHeight = 45.0f;
+        public const string ItenFontName = "";
+        public const float ItemFontSize = 15.0f;
+
+        public string Text { get; set; }
+        public Action Callback { get; set; }
+        public Control? ShortcutControl { get; set; }
+        public Menu BindedSubmenu { get; set; }
+
+        public string DisplayText
+        {
+            get
+            {
+                string controlStr = ShortcutControl.HasValue ? ShortcutControl.Value.GetDisplayText() : "";
+
+                return Text + (String.IsNullOrEmpty(controlStr) ? "" : $" ({controlStr})");
+            }
+        }
+
+        public MenuItem(string text, Action callback, Control? shortcutControl = null)
+        {
+            Text = text;
+            Callback = callback;
+            ShortcutControl = shortcutControl;
+        }
+
+        public void OnUpdate()
+        {
+        }
+
+        public void OnDraw(Graphics g, float x, int position) // position == 0 -> middle of screen, selected item  ;;  position < 0 -> above middle  ;;  position > 0 -> below middle
+        {
+            float middleY = Game.Resolution.Height / 2 - ItemHeight / 2;
+            float offsetY = (ItemHeight + 3.0f) * position;
+
+            float y = middleY + offsetY;
+
+            RectangleF rect = new RectangleF(x, y, ItemWidth, ItemHeight);
+            g.DrawRectangle(rect, position == 0 ? Color.FromArgb(200, 200, 200) : Color.FromArgb(100, 5, 5, 5));
+
+            string text = DisplayText;
+
+            SizeF textSize = Graphics.MeasureText(text, ItenFontName, ItemFontSize);
+
+            float textX = rect.X + rect.Width * 0.5f - textSize.Width * 0.5f;
+            float textY = rect.Y + rect.Height * 0.5f - textSize.Height * 0.8f;
+
+            g.DrawText(text, ItenFontName, ItemFontSize, new PointF(textX, textY), position == 0 ? Color.FromArgb(0, 0, 0) : Color.FromArgb(100, 240, 240, 240), rect);
+        }
+    }
+}

--- a/Firefighter/PlayerFireEquipmentManager.cs
+++ b/Firefighter/PlayerFireEquipmentManager.cs
@@ -185,11 +185,6 @@
 
             if (Plugin.UserSettings.PEDS.FIREFIGHTER_FLASHLIGHT_ENABLED)
             {
-                if (Game.IsKeyDown(System.Windows.Forms.Keys.L))
-                {
-                    IsFlashlightOn = !IsFlashlightOn;
-                }
-
                 if (IsFlashlightOn)
                 {
                     Vector3 flashlightPos = Plugin.LocalPlayerCharacter.GetOffsetPosition(Plugin.LocalPlayerCharacter.GetPositionOffset(Plugin.LocalPlayerCharacter.GetBonePosition(Plugin.UserSettings.PEDS.FIREFIGHTER_FLASHLIGHT_ORIGIN_BONE)) + Plugin.UserSettings.PEDS.FIREFIGHTER_FLASHLIGHT_ORIGIN_OFFSET.ToVector3());

--- a/Firefighter/PlayerFireEquipmentManager.cs
+++ b/Firefighter/PlayerFireEquipmentManager.cs
@@ -142,45 +142,26 @@
         }
 
         private bool isNearFiretruck = false;
-        private bool isGettingEquipment = false;
         private DateTime lastFiretrucksCheckTime = DateTime.UtcNow;
         private void FireFighterUpdate()
         {
             if ((DateTime.UtcNow - lastFiretrucksCheckTime).TotalSeconds > 3.25)
             {
-                isNearFiretruck = IsFiretruckNearbyPlayer();
-            }
+                bool nearFiretruckNow = IsFiretruckNearbyPlayer();
 
-
-            if (isGettingEquipment)
-            {
-                Game.DisplayHelp("[1] Fire extinguisher~n~[2] Fire gear~n~[3] Axe"); // TODO: some cool GUI for the get equipment menu
-
-                if (Game.IsKeyDown(System.Windows.Forms.Keys.D1))
+                if (isNearFiretruck != nearFiretruckNow)
                 {
-                    HasFireExtinguisher = !HasFireExtinguisher;
+                    if (nearFiretruckNow)
+                    {
+                        CreateVehicleEquipmentMenu();
+                    }
+                    else
+                    {
+                        RemoveVehicleEquipmentMenu();
+                    }
+                }
 
-                    isGettingEquipment = false;
-                }
-                else if (Game.IsKeyDown(System.Windows.Forms.Keys.D2))
-                {
-                    HasFireGear = !HasFireGear;
-
-                    isGettingEquipment = false;
-                }
-                else if (Game.IsKeyDown(System.Windows.Forms.Keys.D3))
-                {
-                    // TODO: use "prop_tool_fireaxe" to give an axe to the player
-                    isGettingEquipment = false;
-                }
-            }
-            else if (isNearFiretruck)
-            {
-                Game.DisplayHelp("Press ~INPUT_CONTEXT~ to get/save equipment", 20);
-                if (Game.IsControlJustPressed(0, GameControl.Context))
-                {
-                    isGettingEquipment = true;
-                }
+                isNearFiretruck = nearFiretruckNow;
             }
 
             if (Plugin.UserSettings.PEDS.FIREFIGHTER_FLASHLIGHT_ENABLED)
@@ -216,6 +197,23 @@
             }
 
             return isNearAnyFiretruck;
+        }
+
+        private void CreateVehicleEquipmentMenu()
+        {
+            PluginMenu.Instance.AddMenu("VEHICLE_EQUIPMENT_SUBMENU");
+
+            PluginMenu.Instance.AddItem("OPEN_VEHICLE_EQUIPMENT_SUBMENU_ITEM", "MAIN_MENU", "Equipment", null, null, "VEHICLE_EQUIPMENT_SUBMENU");
+
+            PluginMenu.Instance.AddItem("VEHICLE_EQUIPMENT_FIRE_GEAR_ITEM", "VEHICLE_EQUIPMENT_SUBMENU", HasFireGear ? "Leave Fire Gear" : "Get Fire Gear", () => { HasFireGear = !HasFireGear; });
+            PluginMenu.Instance.AddItem("VEHICLE_EQUIPMENT_FIRE_EXTINGUISHER_ITEM", "VEHICLE_EQUIPMENT_SUBMENU", HasFireGear ? "Leave Fire Extinguisher" : "Get Fire Extinguisher", () => { HasFireExtinguisher = !HasFireExtinguisher; });
+        }
+
+        private void RemoveVehicleEquipmentMenu()
+        {
+            PluginMenu.Instance.RemoveMenu("VEHICLE_EQUIPMENT_SUBMENU");
+
+            PluginMenu.Instance.RemoveItem("OPEN_VEHICLE_EQUIPMENT_SUBMENU_ITEM");
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -57,6 +57,8 @@
 
                 hose.Update();
 
+                PluginMenu.Instance.Update();
+
                 PlayerManager.Instance.Update();
 
                 FireStationsManager.Instance.Update();

--- a/PluginMenu.cs
+++ b/PluginMenu.cs
@@ -1,5 +1,10 @@
 ﻿namespace EmergencyV
 {
+    // System
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+
     // RPH
     using Rage;
     using Rage.Native;
@@ -16,31 +21,141 @@
                 return instance;
             }
         }
-
-        public Menu MainMenu { get; }
-        public Menu ActionsSubmenu { get; }
-        public Menu RequestBackupSubmenu { get; }
+        
+        public Dictionary<string, Menu> MenusByIdentifier = new Dictionary<string, Menu>();
+        public Dictionary<string, MenuItem> ItemsByIdentifier = new Dictionary<string, MenuItem>();
 
         private PluginMenu()
         {
-            MainMenu = new Menu();
-            ActionsSubmenu = new Menu() { ParentMenu = MainMenu };
-            RequestBackupSubmenu = new Menu() { ParentMenu = MainMenu };
+            AddMenu("MAIN_MENU");
+            AddMenu("ACTIONS_SUBMENU");
+            AddMenu("REQUEST_BACKUP_SUBMENU");
 
-            MainMenu.Items.Add(new MenuItem("Actions", null) { BindedSubmenu = ActionsSubmenu });
-            MainMenu.Items.Add(new MenuItem("Request Backup", null) { BindedSubmenu = RequestBackupSubmenu });
-
+            AddItem("OPEN_ACTIONS_SUBMENU_ITEM", "MAIN_MENU", "Actions", null, null, "ACTIONS_SUBMENU");
+            AddItem("OPEN_REQUEST_BACKUP_SUBMENU_ITEM", "MAIN_MENU", "Request Backup", null, null, "REQUEST_BACKUP_SUBMENU");
 
             if (Plugin.UserSettings.PEDS.FIREFIGHTER_FLASHLIGHT_ENABLED)
-                ActionsSubmenu.Items.Add(new MenuItem("Toggle Flashlight", () => { PlayerFireEquipmentManager.Instance.IsFlashlightOn = !PlayerFireEquipmentManager.Instance.IsFlashlightOn; }, Plugin.Controls["TOGGLE_FLASHLIGHT"]));
+                AddItem("TOGGLE_FLASHLIGHT_ITEM", "ACTIONS_SUBMENU", "Toggle Flashlight", () => { PlayerFireEquipmentManager.Instance.IsFlashlightOn = !PlayerFireEquipmentManager.Instance.IsFlashlightOn; }, Plugin.Controls["TOGGLE_FLASHLIGHT"]);
 
-            RequestBackupSubmenu.Items.Add(new MenuItem("[WIP]", () => { Game.DisplaySubtitle("[WIP]"); }));
+            AddItem("BACKUP_WIP_ITEM", "REQUEST_BACKUP_SUBMENU", "[WIP]", () => { Game.DisplaySubtitle("[WIP]"); });
         }
 
         public void Update()
         {
             if (PlayerManager.Instance.PlayerState != PlayerStateType.Normal && Plugin.Controls["OPEN_MENU"].IsJustPressed())
-                MainMenu.IsVisible = !MainMenu.IsVisible;
+                MenusByIdentifier["MAIN_MENU"].IsVisible = !MenusByIdentifier["MAIN_MENU"].IsVisible;
+        }
+
+        public bool IsMenuAdded(string uniqueIdentifier)
+        {
+            return MenusByIdentifier.ContainsKey(uniqueIdentifier);
+        }
+
+        public bool IsItemAdded(string uniqueIdentifier)
+        {
+            return ItemsByIdentifier.ContainsKey(uniqueIdentifier);
+        }
+
+        public void AddMenu(string uniqueIdentifier)
+        {
+            if (MenusByIdentifier.ContainsKey(uniqueIdentifier))
+                throw new InvalidOperationException($"Cannot add menu with ID \"{uniqueIdentifier}\", it's already added.");
+
+            Game.LogTrivial($"Adding menu - ID:{uniqueIdentifier}");
+
+            Menu m = new Menu();
+            MenusByIdentifier.Add(uniqueIdentifier, m);
+        }
+
+        public void RemoveMenu(string uniqueIdentifier)
+        {
+            if (!MenusByIdentifier.ContainsKey(uniqueIdentifier))
+                throw new InvalidOperationException($"Cannot remove menu with ID \"{uniqueIdentifier}\", it wasn't added or it's already removed.");
+
+            Game.LogTrivial($"Removing menu - ID:{uniqueIdentifier}");
+
+            Menu m = MenusByIdentifier[uniqueIdentifier];
+            if (m.ParentMenu != null && m.ParentMenu.OpenedSubmenu == m)
+                m.ParentMenu.CloseSubmenu();
+            m.Dispose();
+            List<string> keysToRemove = new List<string>();
+            foreach (MenuItem item in m.Items)
+                foreach (KeyValuePair<string, MenuItem> p in ItemsByIdentifier.Where(x => x.Value == item))
+                    keysToRemove.Add(p.Key);
+
+            foreach (string k in keysToRemove)
+                RemoveItem(k);
+
+            MenusByIdentifier.Remove(uniqueIdentifier);
+        }
+
+        public void AddItem(string uniqueIdentifier, string menuIdentifier, string text, Action callback = null, Control? shortcutControl = null, string submenuToBindIdentifier = null)
+        {
+            if (uniqueIdentifier == null)
+                throw new ArgumentNullException(nameof(uniqueIdentifier));
+            if (menuIdentifier == null)
+                throw new ArgumentNullException(nameof(menuIdentifier));
+
+            if (ItemsByIdentifier.ContainsKey(uniqueIdentifier))
+                throw new InvalidOperationException($"Cannot add item with ID \"{uniqueIdentifier}\", it's already added.");
+
+            Game.LogTrivial($"Adding menu item - ID:{uniqueIdentifier}");
+
+            MenuItem item = new MenuItem(text, callback, shortcutControl);
+            if (submenuToBindIdentifier != null)
+            {
+                if (!MenusByIdentifier.ContainsKey(submenuToBindIdentifier))
+                    throw new InvalidOperationException($"Cannot bind item with ID \"{uniqueIdentifier}\" to menu with ID \"{submenuToBindIdentifier}\", the menu isn't added.");
+
+                item.BindedSubmenu = MenusByIdentifier[submenuToBindIdentifier];
+                item.BindedSubmenu.ParentMenu = MenusByIdentifier[menuIdentifier];
+            }
+
+            if (!MenusByIdentifier.ContainsKey(menuIdentifier))
+                throw new InvalidOperationException($"Cannot add item with ID \"{uniqueIdentifier}\" to menu with ID \"{submenuToBindIdentifier}\", the menu isn't added.");
+
+            MenusByIdentifier[menuIdentifier].Items.Add(item);
+            ItemsByIdentifier.Add(uniqueIdentifier, item);
+        }
+
+        public void RemoveItem(string uniqueIdentifier)
+        {
+            if (!ItemsByIdentifier.ContainsKey(uniqueIdentifier))
+                throw new InvalidOperationException($"Cannot remove item with ID \"{uniqueIdentifier}\", it wasn't added or it's already removed.");
+
+            Game.LogTrivial($"Removing menu item - ID:{uniqueIdentifier}");
+
+            MenuItem item = ItemsByIdentifier[uniqueIdentifier];
+
+            Menu menu = MenusByIdentifier.FirstOrDefault(p => p.Value.Items.Contains(item)).Value;
+            if (menu != null)
+            {
+                menu.Items.Remove(item);
+                if (menu.SelectedItem == item)
+                    menu.SelectedItem = null;
+            }
+
+            ItemsByIdentifier.Remove(uniqueIdentifier);
+        }
+
+        public void UpdateItem(string uniqueIdentifier, string text, Action callback = null, Control? shortcutControl = null, string submenuToBindIdentifier = null)
+        {
+            if (!ItemsByIdentifier.ContainsKey(uniqueIdentifier))
+                throw new InvalidOperationException($"Cannot update item with ID \"{uniqueIdentifier}\", it wasn't added or it was removed.");
+
+            MenuItem item = ItemsByIdentifier[uniqueIdentifier];
+
+            item.Text = text;
+            item.Callback = callback;
+            item.ShortcutControl = shortcutControl;
+
+            if (submenuToBindIdentifier != null)
+            {
+                if (!MenusByIdentifier.ContainsKey(uniqueIdentifier))
+                    throw new InvalidOperationException($"Cannot bind item with ID \"{uniqueIdentifier}\" to menu with ID \"{submenuToBindIdentifier}\", the menu isn't added.");
+
+                item.BindedSubmenu = MenusByIdentifier[submenuToBindIdentifier];
+            }
         }
     }
 }

--- a/PluginMenu.cs
+++ b/PluginMenu.cs
@@ -1,0 +1,46 @@
+﻿namespace EmergencyV
+{
+    // RPH
+    using Rage;
+    using Rage.Native;
+
+    internal class PluginMenu
+    {
+        private static PluginMenu instance;
+        public static PluginMenu Instance
+        {
+            get
+            {
+                if (instance == null)
+                    instance = new PluginMenu();
+                return instance;
+            }
+        }
+
+        public Menu MainMenu { get; }
+        public Menu ActionsSubmenu { get; }
+        public Menu RequestBackupSubmenu { get; }
+
+        private PluginMenu()
+        {
+            MainMenu = new Menu();
+            ActionsSubmenu = new Menu() { ParentMenu = MainMenu };
+            RequestBackupSubmenu = new Menu() { ParentMenu = MainMenu };
+
+            MainMenu.Items.Add(new MenuItem("Actions", null) { BindedSubmenu = ActionsSubmenu });
+            MainMenu.Items.Add(new MenuItem("Request Backup", null) { BindedSubmenu = RequestBackupSubmenu });
+
+
+            if (Plugin.UserSettings.PEDS.FIREFIGHTER_FLASHLIGHT_ENABLED)
+                ActionsSubmenu.Items.Add(new MenuItem("Toggle Flashlight", () => { PlayerFireEquipmentManager.Instance.IsFlashlightOn = !PlayerFireEquipmentManager.Instance.IsFlashlightOn; }, Plugin.Controls["TOGGLE_FLASHLIGHT"]));
+
+            RequestBackupSubmenu.Items.Add(new MenuItem("[WIP]", () => { Game.DisplaySubtitle("[WIP]"); }));
+        }
+
+        public void Update()
+        {
+            if (PlayerManager.Instance.PlayerState != PlayerStateType.Normal && Plugin.Controls["OPEN_MENU"].IsJustPressed())
+                MainMenu.IsVisible = !MainMenu.IsVisible;
+        }
+    }
+}


### PR DESCRIPTION
Added menu that will hold most of the actions/features of the plugin. This actions will still have a key bind but if the users decides to remove that key bind, he will still be able to use those features through the menu.

Exposed the menu in the API with the methods AddMenu(), RemoveMenu(), AddItem(), RemoveItem() and UpdateItem().

Updated PlayerFireEquipmentManager to add a submenu for the equipment when the player is near a firetruck.

And added the default controls OPEN_MENU and TOGGLE_FLASHLIGHT and the method Control.GetDisplayText(), that returns a string with the keys (or buttons if the controller is being used) for activating the control, for example "LControlKey + K".
